### PR TITLE
IDPT-353: Deploy AWS-D Accounts

### DIFF
--- a/.github/workflows/terraform_pr.yml
+++ b/.github/workflows/terraform_pr.yml
@@ -1,0 +1,49 @@
+---
+name: Terraform Module
+on:
+  pull_request:
+    paths:
+      - '**.tf'
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+jobs:
+  terraform:
+    name: Terraform Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: 0.14
+
+      - name: Terraform Format
+        id: fmt
+        run: terraform fmt -check -diff
+        continue-on-error: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/github-script@v3
+        if: ${{ failure() }}
+        env:
+          RESULT: "terraform\n${{ steps.fmt.outputs.stdout }}"
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const output = `#### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`
+            <details><summary>Show Result</summary>
+
+            \`\`\`${ process.env.RESULT }\`\`\`
+            </details>
+            *Pusher: @${{ github.actor }}, Action: \`${{ github.event_name }}\`, Workflow: \`${{ github.workflow }}\`*`;
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: output
+            })

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ override.tf.json
 
 # Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
 # example: *tfplan*
+
+.idea

--- a/data.tf
+++ b/data.tf
@@ -1,0 +1,9 @@
+data "terraform_remote_state" "ons_tfstate" {
+  backend = "s3"
+
+  config = {
+    bucket = "ons-tfstate"
+    region = "eu-west-2"
+    key    = "default"
+  }
+}

--- a/idp-iam.tf
+++ b/idp-iam.tf
@@ -1,0 +1,135 @@
+resource "aws_organizations_account" "idp_iam" {
+  name  = "idp-iam"
+  email = "aws-registration.ons.047@ons.gov.uk"
+
+  tags = {
+    team = "cia"
+    env  = "iam"
+  }
+
+  provisioner "local-exec" {
+    # AWS accounts aren't quite ready on creation, arbitrary pause before we provision resources inside it
+    command = "sleep 120"
+  }
+}
+
+resource "aws_iam_service_linked_role" "config" {
+  aws_service_name = "config.amazonaws.com"
+}
+
+resource "aws_iam_account_password_policy" "strict" {
+  minimum_password_length        = 14
+  require_uppercase_characters   = true
+  require_lowercase_characters   = true
+  require_numbers                = true
+  require_symbols                = true
+  max_password_age               = 30
+  hard_expiry                    = false
+  allow_users_to_change_password = true
+  password_reuse_prevention      = 10
+}
+
+##############################################
+#             Config Recorder               #
+#############################################
+
+resource "aws_config_configuration_recorder" "config_recorder" {
+  name     = "config-recorder-${aws_organizations_account.idp_iam.id}"
+  role_arn = aws_iam_service_linked_role.config.arn
+
+  recording_group {
+    include_global_resource_types = true
+  }
+}
+
+resource "aws_config_configuration_recorder_status" "config_recorder_status" {
+  depends_on = [aws_config_delivery_channel.config_delivery_channel]
+
+  name       = aws_config_configuration_recorder.config_recorder.name
+  is_enabled = true
+}
+
+resource "aws_config_delivery_channel" "config_delivery_channel" {
+  depends_on = [aws_config_configuration_recorder.config_recorder]
+
+  name           = "config-delivery-channel-${aws_organizations_account.idp_iam.id}"
+  s3_bucket_name = data.terraform_remote_state.ons_tfstate.config_bucket_name
+  sns_topic_arn  = data.terraform_remote_state.ons_tfstate.config_bucket_name
+}
+
+##############################################
+#                  DNS                      #
+#############################################
+
+resource "aws_route53_zone" "zone" {
+  name = "iam.idp.aws.onsdigital.uk"
+}
+
+resource "aws_route53_record" "account_aws_onsdigital_uk_ns" {
+  zone_id = data.terraform_remote_state.ons_tfstate.master_zone_id
+  name    = "${aws_route53_zone.zone.name}."
+  type    = "NS"
+  ttl     = "300"
+
+  records = aws_route53_zone.zone.name_servers
+}
+
+##############################################
+#               Splunk Logs                 #
+#############################################
+
+data "aws_iam_policy_document" "splunk_logs" {
+  statement {
+    sid    = "SplunkAccess"
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = [data.terraform_remote_state.ons_tfstate.splunk_user_arn]
+    }
+
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.splunk_logs.arn}/*"]
+  }
+}
+
+resource "aws_s3_bucket" "splunk_logs" {
+  bucket = "idp-iam-s3-access"
+  acl    = "log-delivery-write"
+
+  policy = data.aws_iam_policy_document.splunk_logs.json
+
+  lifecycle_rule {
+    id      = "log"
+    enabled = true
+
+    expiration {
+      days = 60
+    }
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "splunk_logs" {
+  bucket                  = aws_s3_bucket.splunk_logs[0].id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_notification" "splunk_logs" {
+  bucket = aws_s3_bucket.splunk_logs[0].id
+
+  queue {
+    queue_arn = data.terraform_remote_state.ons_tfstate.ons_s3_access_sqs_queue_arn
+    events    = ["s3:ObjectCreated:*"]
+  }
+}

--- a/idp-mgmt-dev.tf
+++ b/idp-mgmt-dev.tf
@@ -1,0 +1,16 @@
+module "idp_mgmt_dev" {
+  source  = "ONSdigital/account/aws"
+  version = "~> 0.2.0"
+
+  account_env          = "dev"
+  account_team         = "cia"
+  config_bucket        = data.terraform_remote_state.ons_tfstate.config_bucket_name
+  config_sns_topic_arn = data.terraform_remote_state.ons_tfstate.config_sns_topic_arn
+  dns_subdomain        = "dev.mgmt.idp"
+  iam_account_id       = aws_organizations_account.idp_iam.id
+  master_zone_id       = data.terraform_remote_state.ons_tfstate.master_zone_id
+  name                 = "idp-mgmt-dev"
+  root_account_email   = "aws-registration.ons.049@ons.gov.uk"
+  splunk_user_arn      = data.terraform_remote_state.ons_tfstate.splunk_user_arn
+  splunk_logs_sqs_arn  = data.terraform_remote_state.ons_tfstate.ons_s3_access_sqs_queue_arn
+}

--- a/idp-mgmt.tf
+++ b/idp-mgmt.tf
@@ -1,0 +1,16 @@
+module "idp_mgmt" {
+  source  = "ONSdigital/account/aws"
+  version = "~> 0.2.0"
+
+  account_env          = "mgmt"
+  account_team         = "cia"
+  config_bucket        = data.terraform_remote_state.ons_tfstate.config_bucket_name
+  config_sns_topic_arn = data.terraform_remote_state.ons_tfstate.config_bucket_name
+  dns_subdomain        = "mgmt.idp"
+  iam_account_id       = aws_organizations_account.idp_iam.id
+  master_zone_id       = data.terraform_remote_state.ons_tfstate.master_zone_id
+  name                 = "idp-mgmt"
+  root_account_email   = "aws-registration.ons.048@ons.gov.uk"
+  splunk_user_arn      = data.terraform_remote_state.ons_tfstate.splunk_user_arn
+  splunk_logs_sqs_arn  = data.terraform_remote_state.ons_tfstate.ons_s3_access_sqs_queue_arn
+}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,11 @@
+terraform {
+  backend "s3" {
+    bucket = data.terraform_remote_state.ons_tfstate.ons_tfstate
+    key    = "idp-accounts-config.tfstate"
+    region = "eu-west-2"
+  }
+}
+
+provider "aws" {
+  region = var.region
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,29 @@
+output "idp_iam_account_id" {
+  value       = aws_organizations_account.idp_iam.id
+  description = "The Id of the IDP IAM AWS account"
+}
+
+output "idp_mgmt_dev_account_id" {
+  value       = module.idp_mgmt_dev.account_id
+  description = "The Id of the IDP MGMT Dev AWS account"
+}
+
+output "idp_mgmt_account_id" {
+  value       = module.idp_mgmt.account_id
+  description = "The Id of the IDP MGMT AWS account"
+}
+
+output "idp_iam_s3_access_bucket_arn" {
+  value       = aws_s3_bucket.splunk_logs.arn
+  description = "The ARN of the IDP IAM splunk log delivery bucket"
+}
+
+output "idp_mgmt_dev_s3_access_bucket_arn" {
+  value       = module.idp_mgmt_dev.s3_access_bucket_arn
+  description = "The ARN of the IDP MGMT Dev splunk log delivery bucket"
+}
+
+output "idp_mgmt_s3_access_bucket_arn" {
+  value       = module.idp_mgmt.s3_access_bucket_arn
+  description = "The ARN of the IDP MGMT splunk log delivery bucket"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,5 @@
+variable "region" {
+  type        = string
+  default     = "eu-west-1"
+  description = "The AWS region in which to deploy resources"
+}


### PR DESCRIPTION
[Jira Ticket](https://collaborate2.ons.gov.uk/jira/browse/IDPT-353)

[module]: https://github.com/ONSdigital/terraform-aws-account

IDP-MGMT:
- Instantiated [module] to create **idp-mgmt-dev** and **idp-mgmt** AWS accounts

IDP-IAM:
- In order to keep the implementation of the account [module] simple, I'd thought it best not to enable the [module] to provision an IAM type account
- Added required resources to provision base **idp-iam** account