### PR TITLE
IDPT-442: Deploy AWS-D Accounts Pt 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,68 @@ Configuration and provisioning of AWS-D organisation and member accounts
 |------|---------|
 | aws |  >= 3.33.0, < 4.0.0 |
 
+[module]: https://registry.terraform.io/modules/ONSdigital/account/aws/latest
+
+## Usage
+
+This repo instantiates the AWS account [module]. Please refer to the account [module]'s [README](https://github.com/ONSdigital/terraform-aws-account#readme) for usage instructions
+
+To provision an AWS account:
+
+1. Create a file i.e. `idp-documentation.tf`
+
+
+2. Instantiate the account [module]
+
+```terraform
+module "idp_documentation" {
+  source  = "ONSdigital/account/aws"
+  version = "~> 0.2.2"
+
+  account_env        = "documentation"
+  account_team       = "cia"
+  root_account_email = "aws.d.registration.000@ons.gov.uk"
+  name               = "documentation"
+  dns_subdomain      = "doc"
+  master_zone_id     = aws_route53_zone.org_zone.id
+  iam_account_id     = module.iam.account_id
+
+  providers = {
+    aws         = aws.idp-documentation
+    aws.account = aws.account
+  }
+}
+```
+
+**Note**
+
+For a value to the `root_account_email` argument.  Refer to [AWS Accounts Alias List](./README.md#aws-accounts-alias-list) table below and **remember** to mark the selected
+email as `in use`
+
+3. Define a provider referencing the built-in organisation access role.  See: [Provider Config Docs](https://github.com/ONSdigital/terraform-aws-account#provider-configuration)
+
+```terraform
+provider "aws" {
+  alias  = "idp-documentation"
+  region = "eu-west-2"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${module.idp_documentation.account_id}:role/OrganizationAccountAccessRole"
+  }
+}
+```
+
+4. Create a record in the AWS-D organisation hosted zone for the account's delegation set
+
+```terraform
+resource "aws_route53_record" "idp_documentation" {
+  zone_id = aws_route53_zone.org_zone.zone_id
+  name    = module.idp_documentation.zone_name
+  type    = "NS"
+  ttl     = "300"
+  records = module.idp_documentation.zone_name_servers
+}
+```
 
 ## Outputs
 
@@ -28,3 +90,29 @@ Configuration and provisioning of AWS-D organisation and member accounts
 | org\_zone\_name\_servers | The name server records from the organisation route53 zone |
 
 
+### AWS Accounts Alias List
+
+Please amend this table when creating a new AWS account.
+
+| Alias                                | State       | Organization |
+| ------------------------------------ | ------      |:------------:|
+| aws.d.registration.001@ons.gov.uk    | in use      | AWS-D        |
+| aws.d.registration.002@ons.gov.uk    | in use      | AWS-D        |
+| aws.d.registration.003@ons.gov.uk    | in use      | AWS-D        |
+| aws.d.registration.004@ons.gov.uk    | available   | AWS-D        |
+| aws.d.registration.005@ons.gov.uk    | available   | AWS-D        |
+| aws.d.registration.006@ons.gov.uk    | available   | AWS-D        |
+| aws.d.registration.007@ons.gov.uk    | available   | AWS-D        |
+| aws.d.registration.008@ons.gov.uk    | available   | AWS-D        |
+| aws.d.registration.009@ons.gov.uk    | available   | AWS-D        |
+| aws.d.registration.010@ons.gov.uk    | available   | AWS-D        |
+| aws.d.registration.011@ons.gov.uk    | available   | AWS-D        |
+| aws.d.registration.012@ons.gov.uk    | available   | AWS-D        |
+| aws.d.registration.013@ons.gov.uk    | available   | AWS-D        |
+| aws.d.registration.014@ons.gov.uk    | available   | AWS-D        |
+| aws.d.registration.015@ons.gov.uk    | available   | AWS-D        |
+| aws.d.registration.016@ons.gov.uk    | available   | AWS-D        |
+| aws.d.registration.017@ons.gov.uk    | available   | AWS-D        |
+| aws.d.registration.018@ons.gov.uk    | available   | AWS-D        |
+| aws.d.registration.019@ons.gov.uk    | available   | AWS-D        |
+| aws.d.registration.020@ons.gov.uk    | available   | AWS-D        |

--- a/idp-iam.tf
+++ b/idp-iam.tf
@@ -1,0 +1,26 @@
+provider "aws" {
+  alias  = "iam"
+  region = "eu-west-2"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${module.iam.account_id}:role/OrganizationAccountAccessRole"
+  }
+}
+
+module "iam" {
+  source  = "ONSdigital/account/aws"
+  version = "~> 0.2.2"
+
+  account_env        = "iam"
+  account_team       = "cia"
+  root_account_email = "aws.d.registration.001@ons.gov.uk"
+  name               = "iam"
+  dns_subdomain      = "iam"
+  master_zone_id     = aws_route53_zone.org_zone.id
+  iam_account_id     = module.iam.account_id
+
+  providers = {
+    aws         = aws.iam
+    aws.account = aws.account
+  }
+}

--- a/idp-mgmt-dev.tf
+++ b/idp-mgmt-dev.tf
@@ -1,0 +1,34 @@
+provider "aws" {
+  alias  = "idp-mgmt-dev"
+  region = "eu-west-2"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${module.idp_mgmt_dev.account_id}:role/OrganizationAccountAccessRole"
+  }
+}
+
+module "idp_mgmt_dev" {
+  source  = "ONSdigital/account/aws"
+  version = "~> 0.2.2"
+
+  account_env        = "dev"
+  account_team       = "cia"
+  root_account_email = "aws.d.registration.002@ons.gov.uk"
+  name               = "mgmt-dev"
+  dns_subdomain      = "mgmt-dev"
+  master_zone_id     = aws_route53_zone.org_zone.id
+  iam_account_id     = module.iam.account_id
+
+  providers = {
+    aws         = aws.idp-mgmt-dev
+    aws.account = aws.account
+  }
+}
+
+resource "aws_route53_record" "idp_mgmt_dev" {
+  zone_id = aws_route53_zone.org_zone.zone_id
+  name    = module.idp_mgmt_dev.zone_name
+  type    = "NS"
+  ttl     = "300"
+  records = module.idp_mgmt_dev.zone_name_servers
+}

--- a/idp-mgmt.tf
+++ b/idp-mgmt.tf
@@ -1,0 +1,34 @@
+provider "aws" {
+  alias  = "idp-mgmt"
+  region = "eu-west-2"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${module.idp_mgmt.account_id}:role/OrganizationAccountAccessRole"
+  }
+}
+
+module "idp_mgmt" {
+  source  = "ONSdigital/account/aws"
+  version = "~> 0.2.2"
+
+  account_env        = "mgmt"
+  account_team       = "cia"
+  root_account_email = "aws.d.registration.003@ons.gov.uk"
+  name               = "mgmt"
+  dns_subdomain      = "mgmt"
+  master_zone_id     = aws_route53_zone.org_zone.id
+  iam_account_id     = module.iam.account_id
+
+  providers = {
+    aws         = aws.idp-mgmt
+    aws.account = aws.account
+  }
+}
+
+resource "aws_route53_record" "idp_mgmt" {
+  zone_id = aws_route53_zone.org_zone.zone_id
+  name    = module.idp_mgmt.zone_name
+  type    = "NS"
+  ttl     = "300"
+  records = module.idp_mgmt.zone_name_servers
+}

--- a/providers.tf
+++ b/providers.tf
@@ -1,8 +1,0 @@
-provider "aws" {
-  region = "eu-west-2"
-}
-
-provider "aws" {
-  alias  = "account"
-  region = "eu-west-2"
-}

--- a/versions.tf
+++ b/versions.tf
@@ -1,3 +1,12 @@
+provider "aws" {
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "account"
+  region = "eu-west-2"
+}
+
 terraform {
   required_providers {
     aws = {


### PR DESCRIPTION
[Jira Ticket](https://collaborate2.ons.gov.uk/jira/browse/IDPT-442)

- Deployed IAM, MGMT and MGMT-DEV accounts to AWS-D organisation
- Refactored route53 delegate config to avoid having to define permissions for the individual accounts themselves (**Documented**)
- Updated README with instructions on account provisioning


**Deployed**